### PR TITLE
マスタースレーブコントローラの追加

### DIFF
--- a/crane_plus_control/config/master_slave.yaml
+++ b/crane_plus_control/config/master_slave.yaml
@@ -11,8 +11,10 @@ crane_master_slave_controller:
   ros__parameters:
     master_joints:
       - crane_plus_joint1
-      # - crane_plus_joint2
-      # - crane_plus_joint3
-      # - crane_plus_joint4
+      - crane_plus_joint2
     slave_joints:
       - crane_x7_joint1
+      - crane_x7_joint2
+    invert_inputs:
+      - false
+      - true

--- a/crane_plus_control/config/master_slave.yaml
+++ b/crane_plus_control/config/master_slave.yaml
@@ -1,0 +1,18 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 100  # Hz
+
+    crane_master_slave_controller:
+      type: master_slave_controller/MasterSlaveController
+    joint_state_controller:
+      type: joint_state_controller/JointStateController
+
+crane_master_slave_controller:
+  ros__parameters:
+    master_joints:
+      - crane_plus_joint1
+      # - crane_plus_joint2
+      # - crane_plus_joint3
+      # - crane_plus_joint4
+    slave_joints:
+      - crane_x7_joint1

--- a/crane_plus_control/config/master_slave.yaml
+++ b/crane_plus_control/config/master_slave.yaml
@@ -12,9 +12,18 @@ crane_master_slave_controller:
     master_joints:
       - crane_plus_joint1
       - crane_plus_joint2
+      - crane_plus_joint3
+      - crane_plus_joint4
+      - crane_plus_joint_hand
     slave_joints:
       - crane_x7_joint1
       - crane_x7_joint2
+      - crane_x7_joint4
+      - crane_x7_joint6
+      - crane_x7_joint_hand
     invert_inputs:
+      - false
+      - true
+      - false
       - false
       - true

--- a/crane_plus_control/include/crane_plus_control/crane_plus_driver.hpp
+++ b/crane_plus_control/include/crane_plus_control/crane_plus_driver.hpp
@@ -34,6 +34,7 @@ public:
   bool write_goal_joint_positions(const std::vector<double> & goal_positions);
   bool write_moving_speed_rpm(const uint8_t dxl_id, const double speed_rpm);
   bool write_moving_speed_rpm_all(const double speed_rpm);
+  bool write_torque_limits(const std::vector<double> & torque_limits);
   bool read_present_joint_positions(std::vector<double> * joint_positions);
   bool read_present_joint_speeds(std::vector<double> * joint_speeds);
   bool read_present_joint_loads(std::vector<double> * joint_loads);

--- a/crane_plus_control/include/crane_plus_control/crane_plus_hardware.hpp
+++ b/crane_plus_control/include/crane_plus_control/crane_plus_hardware.hpp
@@ -72,6 +72,7 @@ private:
   double timeout_seconds_;
 
   std::vector<double> hw_position_commands_;
+  std::vector<double> hw_torque_limit_commands_;
   std::vector<double> hw_position_states_;
   std::vector<double> hw_velocity_states_;
   std::vector<double> hw_load_states_;

--- a/crane_plus_control/launch/crane_master_slave_control.launch.py
+++ b/crane_plus_control/launch/crane_master_slave_control.launch.py
@@ -1,0 +1,65 @@
+# Copyright 2021 RT Corporation, ShotaAk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch_ros.actions import Node
+import xacro
+
+
+def generate_launch_description():
+    # Get URDF via xacro
+    robot_description_path = os.path.join(
+        get_package_share_directory('crane_plus_description'),
+        'urdf',
+        'crane_plus.urdf.xacro')
+    robot_description_config = xacro.process_file(robot_description_path)
+    robot_description = {'robot_description': robot_description_config.toxml()}
+
+    crane_plus_controllers = os.path.join(
+        get_package_share_directory('crane_plus_control'),
+        'config',
+        'master_slave.yaml'
+        )
+
+    controller_manager = Node(
+        package='controller_manager',
+        executable='ros2_control_node',
+        parameters=[robot_description, crane_plus_controllers],
+        output={
+          'stdout': 'screen',
+          'stderr': 'screen',
+          },
+        )
+
+    joint_state_controller = ExecuteProcess(
+      cmd=['ros2', 'control', 'load_start_controller', 'joint_state_controller'],
+      output='screen',
+      shell=True
+    )
+
+    crane_master_slave_controller = ExecuteProcess(
+      cmd=['ros2', 'control', 'load_start_controller', 'crane_master_slave_controller'],
+      output='screen',
+      shell=True
+    )
+
+    return LaunchDescription([
+      controller_manager,
+      joint_state_controller,
+      crane_master_slave_controller
+    ])

--- a/crane_plus_description/urdf/crane_plus.ros2_control.xacro
+++ b/crane_plus_description/urdf/crane_plus.ros2_control.xacro
@@ -36,6 +36,10 @@
           <param name="min">${joint_1_lower_limit}</param>
           <param name="max">${joint_1_upper_limit}</param>
         </command_interface>
+        <command_interface name="torque_limit">
+          <param name="min">0</param>
+          <param name="max">100</param>
+        </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="load"/>
@@ -48,6 +52,10 @@
         <command_interface name="position">
           <param name="min">${joint_2_lower_limit}</param>
           <param name="max">${joint_2_upper_limit}</param>
+        </command_interface>
+        <command_interface name="torque_limit">
+          <param name="min">0</param>
+          <param name="max">100</param>
         </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
@@ -62,6 +70,10 @@
           <param name="min">${joint_3_lower_limit}</param>
           <param name="max">${joint_3_upper_limit}</param>
         </command_interface>
+        <command_interface name="torque_limit">
+          <param name="min">0</param>
+          <param name="max">100</param>
+        </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="load"/>
@@ -75,6 +87,10 @@
           <param name="min">${joint_4_lower_limit}</param>
           <param name="max">${joint_4_upper_limit}</param>
         </command_interface>
+        <command_interface name="torque_limit">
+          <param name="min">0</param>
+          <param name="max">100</param>
+        </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
         <state_interface name="load"/>
@@ -87,6 +103,10 @@
         <command_interface name="position">
           <param name="min">${joint_hand_lower_limit}</param>
           <param name="max">${joint_hand_upper_limit}</param>
+        </command_interface>
+        <command_interface name="torque_limit">
+          <param name="min">0</param>
+          <param name="max">100</param>
         </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>

--- a/crane_plus_description/urdf/crane_plus.ros2_control.xacro
+++ b/crane_plus_description/urdf/crane_plus.ros2_control.xacro
@@ -162,6 +162,42 @@
         <param name="dxl_id">5</param>
       </joint>
 
+      <joint name="crane_x7_joint5">
+        <command_interface name="position">
+          <param name="min">"${90.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+          <param name="max">"${270.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <param name="dxl_id">6</param>
+      </joint>
+
+      <joint name="crane_x7_joint6">
+        <command_interface name="position">
+          <param name="min">"${90.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+          <param name="max">"${270.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <param name="dxl_id">7</param>
+      </joint>
+
+      <joint name="crane_x7_joint7">
+        <command_interface name="position">
+          <param name="min">"${90.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+          <param name="max">"${270.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <param name="dxl_id">8</param>
+      </joint>
+
+      <joint name="crane_x7_joint_hand">
+        <command_interface name="position">
+          <param name="min">"${0.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+          <param name="max">"${90.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <param name="dxl_id">9</param>
+      </joint>
+
     </ros2_control>
 
   </xacro:macro>

--- a/crane_plus_description/urdf/crane_plus.ros2_control.xacro
+++ b/crane_plus_description/urdf/crane_plus.ros2_control.xacro
@@ -135,14 +135,32 @@
         <param name="dxl_id">2</param>
       </joint>
 
-      <!-- <joint name="crane_x7_joint2">
+      <joint name="crane_x7_joint2">
         <command_interface name="position">
-          <param name="min">-1.57</param>
-          <param name="max">1.57</param>
+          <param name="min">"${90.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+          <param name="max">"${270.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
         </command_interface>
         <state_interface name="position"/>
         <param name="dxl_id">3</param>
-      </joint> -->
+      </joint>
+
+      <joint name="crane_x7_joint3">
+        <command_interface name="position">
+          <param name="min">"${90.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+          <param name="max">"${270.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <param name="dxl_id">4</param>
+      </joint>
+
+      <joint name="crane_x7_joint4">
+        <command_interface name="position">
+          <param name="min">"${150.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+          <param name="max">"${0.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <param name="dxl_id">5</param>
+      </joint>
 
     </ros2_control>
 

--- a/crane_plus_description/urdf/crane_plus.ros2_control.xacro
+++ b/crane_plus_description/urdf/crane_plus.ros2_control.xacro
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:property name="M_PI" value="3.14159"/>
+  <xacro:property name="TO_RADIAN" value="${M_PI / 180.0}"/>
+  <xacro:property name="X7_SERVO_HOME" value="${TO_RADIAN * 180.0}"/>
+
   <xacro:macro name="crane_plus_ros2_control_settings"
     params="name
             name_joint_1
@@ -93,5 +97,34 @@
       </joint>
 
     </ros2_control>
+
+    <ros2_control name="crane_x7" type="system">
+      <hardware>
+        <plugin>crane_x7_hardware/CraneX7Hardware</plugin>
+        <param name="port_name">/dev/ttyUSB1</param>
+        <param name="baudrate">3000000</param>
+        <param name="timeout_seconds">5.0</param>
+      </hardware>
+
+      <joint name="crane_x7_joint1">
+        <command_interface name="position">
+          <param name="min">"${90.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+          <param name="max">"${270.0 * TO_RADIAN - X7_SERVO_HOME}"</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <param name="dxl_id">2</param>
+      </joint>
+
+      <!-- <joint name="crane_x7_joint2">
+        <command_interface name="position">
+          <param name="min">-1.57</param>
+          <param name="max">1.57</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <param name="dxl_id">3</param>
+      </joint> -->
+
+    </ros2_control>
+
   </xacro:macro>
 </robot>

--- a/crane_x7_hardware/CMakeLists.txt
+++ b/crane_x7_hardware/CMakeLists.txt
@@ -1,0 +1,82 @@
+cmake_minimum_required(VERSION 3.5)
+project(crane_x7_hardware)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(dynamixel_sdk REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+
+## COMPILE
+set(LIBRARY_NAME "crane_x7_hardware")
+add_library(
+  ${LIBRARY_NAME}
+  SHARED
+  src/crane_x7_hardware.cpp src/crane_x7_driver.cpp
+)
+target_include_directories(
+  ${LIBRARY_NAME}
+  PRIVATE
+  include
+)
+ament_target_dependencies(
+  ${LIBRARY_NAME}
+  dynamixel_sdk
+  hardware_interface
+  pluginlib
+  rclcpp
+)
+
+pluginlib_export_plugin_description_file(hardware_interface crane_x7_hardware.xml)
+
+# INSTALL
+install(
+  TARGETS ${LIBRARY_NAME}
+  DESTINATION lib
+)
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+# install(DIRECTORY
+#   launch
+#   config
+#   DESTINATION share/${PROJECT_NAME}/
+# )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+## EXPORTS
+ament_export_include_directories(
+  include
+)
+ament_export_libraries(
+  ${LIBRARY_NAME}
+)
+ament_export_dependencies(
+  dynamixel_sdk
+  hardware_interface
+  pluginlib
+  rclcpp
+)
+
+ament_package()

--- a/crane_x7_hardware/crane_x7_hardware.xml
+++ b/crane_x7_hardware/crane_x7_hardware.xml
@@ -1,0 +1,9 @@
+<library path="crane_x7_hardware">
+  <class name="crane_x7_hardware/CraneX7Hardware"
+         type="crane_x7_hardware::CraneX7Hardware"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>
+      A CRANE-X7 hardware plugin for the ros2_control.
+    </description>
+  </class>
+</library>

--- a/crane_x7_hardware/include/crane_x7_hardware/crane_x7_driver.hpp
+++ b/crane_x7_hardware/include/crane_x7_hardware/crane_x7_driver.hpp
@@ -1,0 +1,53 @@
+// Copyright 2021 RT Corporation, ShotaAk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CRANE_X7_HARDWARE__CRANE_X7_DRIVER_HPP_
+#define CRANE_X7_HARDWARE__CRANE_X7_DRIVER_HPP_
+
+#include <dynamixel_sdk/dynamixel_sdk.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+class CraneX7Driver
+{
+public:
+  CraneX7Driver(const std::string port_name, const int baudrate, std::vector<uint8_t> id_list);
+  ~CraneX7Driver();
+
+  bool open_port(void);
+  void close_port(void);
+  std::string get_last_error_log(void);
+
+  bool torque_enable(const bool enable);
+  bool write_goal_joint_positions(const std::vector<double> & goal_positions);
+  bool read_present_joint_positions(std::vector<double> * joint_positions);
+
+private:
+  std::shared_ptr<dynamixel::PortHandler> dxl_port_handler_;
+  std::shared_ptr<dynamixel::PacketHandler> dxl_packet_handler_;
+  int baudrate_;
+  std::vector<uint8_t> id_list_;
+  std::string last_error_log_;
+
+  bool read_1byte_list(const uint16_t address, std::vector<uint8_t> * buffer);
+  bool read_4byte_list(const uint16_t address, std::vector<uint32_t> * buffer);
+  bool parse_dxl_error(
+    const std::string func_name, const uint8_t dxl_id,
+    const int dxl_comm_result, const uint8_t dxl_packet_error);
+  double dxl_pos_to_radian(const uint32_t position);
+  uint32_t radian_to_dxl_pos(const double position);
+};
+
+#endif  // CRANE_X7_HARDWARE__CRANE_X7_DRIVER_HPP_

--- a/crane_x7_hardware/include/crane_x7_hardware/crane_x7_driver.hpp
+++ b/crane_x7_hardware/include/crane_x7_hardware/crane_x7_driver.hpp
@@ -46,7 +46,7 @@ private:
   bool parse_dxl_error(
     const std::string func_name, const uint8_t dxl_id,
     const int dxl_comm_result, const uint8_t dxl_packet_error);
-  double dxl_pos_to_radian(const uint32_t position);
+  double dxl_pos_to_radian(const int position);
   uint32_t radian_to_dxl_pos(const double position);
 };
 

--- a/crane_x7_hardware/include/crane_x7_hardware/crane_x7_hardware.hpp
+++ b/crane_x7_hardware/include/crane_x7_hardware/crane_x7_hardware.hpp
@@ -1,0 +1,81 @@
+// Copyright 2021 RT Corporation, ShotaAk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef CRANE_X7_HARDWARE__CRANE_X7_HARDWARE_HPP_
+#define CRANE_X7_HARDWARE__CRANE_X7_HARDWARE_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "crane_x7_hardware/crane_x7_driver.hpp"
+#include "crane_x7_hardware/visibility_control.h"
+#include "hardware_interface/base_interface.hpp"
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/hardware_interface_status_values.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using hardware_interface::return_type;
+
+namespace crane_x7_hardware
+{
+class CraneX7Hardware : public
+  hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+{
+public:
+  RCLCPP_SHARED_PTR_DEFINITIONS(CraneX7Hardware)
+
+  CRANE_X7_HARDWARE_PUBLIC
+  ~CraneX7Hardware();
+
+  CRANE_X7_HARDWARE_PUBLIC
+  return_type configure(const hardware_interface::HardwareInfo & info) override;
+
+  CRANE_X7_HARDWARE_PUBLIC
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+
+  CRANE_X7_HARDWARE_PUBLIC
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  CRANE_X7_HARDWARE_PUBLIC
+  return_type start() override;
+
+  CRANE_X7_HARDWARE_PUBLIC
+  return_type stop() override;
+
+  CRANE_X7_HARDWARE_PUBLIC
+  return_type read() override;
+
+  CRANE_X7_HARDWARE_PUBLIC
+  return_type write() override;
+
+private:
+  bool communication_timeout();
+
+  std::shared_ptr<CraneX7Driver> driver_;
+  double timeout_seconds_;
+
+  std::vector<double> hw_position_commands_;
+  std::vector<double> hw_position_states_;
+
+  rclcpp::Time prev_comm_timestamp_;
+};
+}  // namespace crane_x7_hardware
+
+#endif  // CRANE_X7_HARDWARE__CRANE_X7_HARDWARE_HPP_

--- a/crane_x7_hardware/include/crane_x7_hardware/visibility_control.h
+++ b/crane_x7_hardware/include/crane_x7_hardware/visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all rclcpp headers which declare symbols
+ * which are defined in the rclcpp library. When not building the rclcpp
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the rclcpp
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef CRANE_X7_HARDWARE__VISIBILITY_CONTROL_H_
+#define CRANE_X7_HARDWARE__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define CRANE_X7_HARDWARE_EXPORT __attribute__((dllexport))
+#define CRANE_X7_HARDWARE_IMPORT __attribute__((dllimport))
+#else
+#define CRANE_X7_HARDWARE_EXPORT __declspec(dllexport)
+#define CRANE_X7_HARDWARE_IMPORT __declspec(dllimport)
+#endif
+#ifdef CRANE_X7_HARDWARE_BUILDING_DLL
+#define CRANE_X7_HARDWARE_PUBLIC CRANE_X7_HARDWARE_EXPORT
+#else
+#define CRANE_X7_HARDWARE_PUBLIC CRANE_X7_HARDWARE_IMPORT
+#endif
+#define CRANE_X7_HARDWARE_PUBLIC_TYPE CRANE_X7_HARDWARE_PUBLIC
+#define CRANE_X7_HARDWARE_LOCAL
+#else
+#define CRANE_X7_HARDWARE_EXPORT __attribute__((visibility("default")))
+#define CRANE_X7_HARDWARE_IMPORT
+#if __GNUC__ >= 4
+#define CRANE_X7_HARDWARE_PUBLIC __attribute__((visibility("default")))
+#define CRANE_X7_HARDWARE_LOCAL __attribute__((visibility("hidden")))
+#else
+#define CRANE_X7_HARDWARE_PUBLIC
+#define CRANE_X7_HARDWARE_LOCAL
+#endif
+#define CRANE_X7_HARDWARE_PUBLIC_TYPE
+#endif
+
+#endif  // CRANE_X7_HARDWARE__VISIBILITY_CONTROL_H_

--- a/crane_x7_hardware/package.xml
+++ b/crane_x7_hardware/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>crane_x7_hardware</name>
+  <version>0.1.0</version>
+  <description>CRANE-X7 hardware package</description>
+  <maintainer email="macakasit@gmail.com">shotaak</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>dynamixel_sdk</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/crane_x7_hardware/src/crane_x7_driver.cpp
+++ b/crane_x7_hardware/src/crane_x7_driver.cpp
@@ -192,7 +192,7 @@ bool CraneX7Driver::parse_dxl_error(
   return retval;
 }
 
-double CraneX7Driver::dxl_pos_to_radian(const uint32_t position)
+double CraneX7Driver::dxl_pos_to_radian(const int position)
 {
   return (position - DXL_HOME_POSITION) * TO_RADIANS;
 }

--- a/crane_x7_hardware/src/crane_x7_driver.cpp
+++ b/crane_x7_hardware/src/crane_x7_driver.cpp
@@ -1,0 +1,203 @@
+// Copyright 2021 RT Corporation, ShotaAk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "crane_x7_hardware/crane_x7_driver.hpp"
+
+constexpr double PROTOCOL_VERSION = 2.0;
+constexpr int DXL_HOME_POSITION = 2048;
+constexpr double TO_RADIANS = (180.0 / 2048.0) * M_PI / 180.0;
+constexpr double TO_DXL_POS = 1.0 / TO_RADIANS;
+
+// Dynamixel XM Series address table
+// Ref: https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/
+constexpr uint16_t ADDR_TORQUE_ENABLE = 64;
+constexpr uint16_t ADDR_GOAL_POSITION = 116;
+constexpr uint16_t ADDR_PRESENT_POSITION = 132;
+
+CraneX7Driver::CraneX7Driver(
+  const std::string port_name, const int baudrate,
+  std::vector<uint8_t> id_list)
+: baudrate_(baudrate), id_list_(id_list)
+{
+  dxl_port_handler_ = std::shared_ptr<dynamixel::PortHandler>(
+    dynamixel::PortHandler::getPortHandler(port_name.c_str()));
+  dxl_packet_handler_ = std::shared_ptr<dynamixel::PacketHandler>(
+    dynamixel::PacketHandler::getPacketHandler(PROTOCOL_VERSION));
+}
+
+CraneX7Driver::~CraneX7Driver()
+{
+  close_port();
+}
+
+bool CraneX7Driver::open_port(void)
+{
+  if (!dxl_port_handler_->openPort()) {
+    last_error_log_ = std::string(__func__) + ": unable to open dynamixel port: " +
+      dxl_port_handler_->getPortName();
+    return false;
+  }
+
+  if (!dxl_port_handler_->setBaudRate(baudrate_)) {
+    last_error_log_ = std::string(__func__) + ": unable to set baudrate" +
+      std::to_string(dxl_port_handler_->getBaudRate());
+    return false;
+  }
+
+  return true;
+}
+
+void CraneX7Driver::close_port(void)
+{
+  dxl_port_handler_->closePort();
+}
+
+std::string CraneX7Driver::get_last_error_log(void)
+{
+  return last_error_log_;
+}
+
+bool CraneX7Driver::torque_enable(const bool enable)
+{
+  bool retval = true;
+  for (auto dxl_id : id_list_) {
+    uint8_t dxl_error = 0;
+    int dxl_result = dxl_packet_handler_->write1ByteTxRx(
+      dxl_port_handler_.get(),
+      dxl_id, ADDR_TORQUE_ENABLE, enable, &dxl_error);
+
+    if (!parse_dxl_error(std::string(__func__), dxl_id, dxl_result, dxl_error)) {
+      retval = false;
+    }
+  }
+
+  return retval;
+}
+
+bool CraneX7Driver::write_goal_joint_positions(const std::vector<double> & goal_positions)
+{
+  if (goal_positions.size() != id_list_.size()) {
+    last_error_log_ = std::string(__func__) + ": vectors size does not match: " +
+      " goal_positions:" + std::to_string(goal_positions.size()) +
+      ", id_list:" + std::to_string(id_list_.size());
+    return false;
+  }
+
+  bool retval = true;
+
+  for (size_t i = 0; i < goal_positions.size(); i++) {
+    uint8_t dxl_error = 0;
+    uint32_t goal_position = radian_to_dxl_pos(goal_positions[i]);
+    auto dxl_id = id_list_[i];
+    int dxl_result = dxl_packet_handler_->write4ByteTxRx(
+      dxl_port_handler_.get(),
+      dxl_id, ADDR_GOAL_POSITION, goal_position, &dxl_error);
+
+    if (!parse_dxl_error(std::string(__func__), dxl_id, dxl_result, dxl_error)) {
+      retval = false;
+    }
+  }
+
+  return retval;
+}
+
+
+bool CraneX7Driver::read_present_joint_positions(std::vector<double> * joint_positions)
+{
+  std::vector<uint32_t> buffer;
+  bool retval = read_4byte_list(ADDR_PRESENT_POSITION, &buffer);
+
+  for (auto data : buffer) {
+    joint_positions->push_back(dxl_pos_to_radian(data));
+  }
+
+  return retval;
+}
+
+bool CraneX7Driver::read_1byte_list(const uint16_t address, std::vector<uint8_t> * buffer)
+{
+  bool retval = true;
+  for (auto dxl_id : id_list_) {
+    uint8_t dxl_error = 0;
+    uint8_t data = 0;
+    int dxl_result = dxl_packet_handler_->read1ByteTxRx(
+      dxl_port_handler_.get(),
+      dxl_id, address, &data, &dxl_error);
+
+    if (!parse_dxl_error(std::string(__func__), dxl_id, dxl_result, dxl_error)) {
+      retval = false;
+    }
+
+    buffer->push_back(data);
+  }
+
+  return retval;
+}
+
+bool CraneX7Driver::read_4byte_list(const uint16_t address, std::vector<uint32_t> * buffer)
+{
+  bool retval = true;
+  for (auto dxl_id : id_list_) {
+    uint8_t dxl_error = 0;
+    uint32_t data = 0;
+    int dxl_result = dxl_packet_handler_->read4ByteTxRx(
+      dxl_port_handler_.get(),
+      dxl_id, address, &data, &dxl_error);
+
+    if (!parse_dxl_error(std::string(__func__), dxl_id, dxl_result, dxl_error)) {
+      retval = false;
+    }
+
+    buffer->push_back(data);
+  }
+
+  return retval;
+}
+
+bool CraneX7Driver::parse_dxl_error(
+  const std::string func_name, const uint8_t dxl_id,
+  const int dxl_comm_result, const uint8_t dxl_packet_error)
+{
+  bool retval = true;
+
+  if (dxl_comm_result != COMM_SUCCESS) {
+    last_error_log_ = func_name + ": dxl_id: " + std::to_string(dxl_id) + " :" +
+      std::string(dxl_packet_handler_->getTxRxResult(dxl_comm_result));
+    retval = false;
+  }
+
+  if (dxl_packet_error != 0) {
+    last_error_log_ = func_name + ": dxl_id: " + std::to_string(dxl_id) + " :" +
+      std::string(dxl_packet_handler_->getRxPacketError(dxl_packet_error));
+    retval = false;
+  }
+
+  return retval;
+}
+
+double CraneX7Driver::dxl_pos_to_radian(const uint32_t position)
+{
+  return (position - DXL_HOME_POSITION) * TO_RADIANS;
+}
+
+uint32_t CraneX7Driver::radian_to_dxl_pos(const double position)
+{
+  return position * TO_DXL_POS + DXL_HOME_POSITION;
+}

--- a/crane_x7_hardware/src/crane_x7_hardware.cpp
+++ b/crane_x7_hardware/src/crane_x7_hardware.cpp
@@ -1,0 +1,217 @@
+// Copyright 2021 RT Corporation, ShotaAk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "crane_x7_hardware/crane_x7_hardware.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+
+namespace crane_x7_hardware
+{
+
+CraneX7Hardware::~CraneX7Hardware()
+{
+  driver_->torque_enable(false);
+  driver_->close_port();
+}
+
+return_type CraneX7Hardware::configure(
+  const hardware_interface::HardwareInfo & info)
+{
+  if (configure_default(info) != return_type::OK) {
+    return return_type::ERROR;
+  }
+
+  // Get parameters from URDF
+  // Initialize member variables
+  std::string port_name = info_.hardware_parameters["port_name"];
+  int baudrate = std::stoi(info_.hardware_parameters["baudrate"]);
+  timeout_seconds_ = std::stod(info_.hardware_parameters["timeout_seconds"]);
+
+  std::vector<uint8_t> dxl_id_list;
+  for (auto joint : info_.joints) {
+    if (joint.parameters["dxl_id"] != "") {
+      dxl_id_list.push_back(std::stoi(joint.parameters["dxl_id"]));
+    } else {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("CraneX7Hardware"),
+        "Joint '%s' does not have 'dxl_id' parameter.",
+        joint.name.c_str());
+      return return_type::ERROR;
+    }
+  }
+
+  hw_position_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_position_states_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+
+  // Open a crane_x7_driver
+  driver_ = std::make_shared<CraneX7Driver>(port_name, baudrate, dxl_id_list);
+  if (!driver_->open_port()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("CraneX7Hardware"), driver_->get_last_error_log());
+    return return_type::ERROR;
+  }
+  if (!driver_->torque_enable(false)) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("CraneX7Hardware"), driver_->get_last_error_log());
+    return return_type::ERROR;
+  }
+
+  // Verify that the interface required by CraneX7Hardware is set in the URDF.
+  for (const hardware_interface::ComponentInfo & joint : info_.joints) {
+    if (joint.command_interfaces.size() != 1) {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("CraneX7Hardware"),
+        "Joint '%s' has %d command interfaces found. 1 expected.",
+        joint.name.c_str(), joint.command_interfaces.size());
+      return return_type::ERROR;
+    }
+
+    if (joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION) {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("CraneX7Hardware"),
+        "Joint '%s' have %s command interfaces found. '%s' expected.",
+        joint.name.c_str(), joint.command_interfaces[0].name.c_str(),
+        hardware_interface::HW_IF_POSITION);
+      return return_type::ERROR;
+    }
+  }
+
+  status_ = hardware_interface::status::CONFIGURED;
+  return return_type::OK;
+}
+
+std::vector<hardware_interface::StateInterface>
+CraneX7Hardware::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  for (uint i = 0; i < info_.joints.size(); i++) {
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION,
+        &hw_position_states_[i])
+    );
+  }
+
+  return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface>
+CraneX7Hardware::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
+  for (uint i = 0; i < info_.joints.size(); i++) {
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION,
+        &hw_position_commands_[i])
+    );
+  }
+
+  return command_interfaces;
+}
+
+return_type CraneX7Hardware::start()
+{
+  if (!driver_->torque_enable(false)) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("CraneX7Hardware"),
+      driver_->get_last_error_log());
+    return return_type::ERROR;
+  }
+  // Set current timestamp to disable the communication timeout.
+  prev_comm_timestamp_ = rclcpp::Clock().now();
+
+  // Set current joint positions to hw_position_commands.
+  read();
+  for (uint i = 0; i < hw_position_commands_.size(); i++) {
+    hw_position_commands_[i] = hw_position_states_[i];
+  }
+
+  status_ = hardware_interface::status::STARTED;
+  return return_type::OK;
+}
+
+return_type CraneX7Hardware::stop()
+{
+  driver_->torque_enable(false);
+  status_ = hardware_interface::status::STOPPED;
+  return return_type::OK;
+}
+
+return_type CraneX7Hardware::read()
+{
+  if (communication_timeout()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("CraneX7Hardware"), "Communication timeout!");
+    return return_type::ERROR;
+  }
+
+  std::vector<double> joint_positions;
+  if (!driver_->read_present_joint_positions(&joint_positions)) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("CraneX7Hardware"),
+      driver_->get_last_error_log());
+    return return_type::ERROR;
+  } else {
+    for (uint i = 0; i < hw_position_states_.size(); ++i) {
+      hw_position_states_[i] = joint_positions[i];
+    }
+  }
+
+  prev_comm_timestamp_ = rclcpp::Clock().now();
+  return return_type::OK;
+}
+
+return_type CraneX7Hardware::write()
+{
+  if (communication_timeout()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("CraneX7Hardware"), "Communication timeout!");
+    return return_type::ERROR;
+  }
+
+  if (!driver_->write_goal_joint_positions(hw_position_commands_)) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("CraneX7Hardware"),
+      driver_->get_last_error_log());
+    return return_type::ERROR;
+  }
+
+  prev_comm_timestamp_ = rclcpp::Clock().now();
+  return return_type::OK;
+}
+
+bool CraneX7Hardware::communication_timeout()
+{
+  if (rclcpp::Clock().now().seconds() - prev_comm_timestamp_.seconds() >= timeout_seconds_) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+}  // namespace crane_x7_hardware
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(
+  crane_x7_hardware::CraneX7Hardware,
+  hardware_interface::SystemInterface
+)

--- a/crane_x7_hardware/src/crane_x7_hardware.cpp
+++ b/crane_x7_hardware/src/crane_x7_hardware.cpp
@@ -129,7 +129,7 @@ CraneX7Hardware::export_command_interfaces()
 
 return_type CraneX7Hardware::start()
 {
-  if (!driver_->torque_enable(false)) {
+  if (!driver_->torque_enable(true)) {
     RCLCPP_ERROR(
       rclcpp::get_logger("CraneX7Hardware"),
       driver_->get_last_error_log());

--- a/master_slave_controller/CMakeLists.txt
+++ b/master_slave_controller/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.5)
+project(master_slave_controller)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(controller_interface REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+
+## COMPILE
+set(LIBRARY_NAME "master_slave_controller")
+add_library(
+  ${LIBRARY_NAME}
+  SHARED
+  src/master_slave_controller.cpp
+)
+target_include_directories(
+  ${LIBRARY_NAME}
+  PRIVATE 
+  include
+)
+ament_target_dependencies(
+  ${LIBRARY_NAME}
+  controller_interface
+  hardware_interface
+  pluginlib
+  rclcpp_lifecycle
+)
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${LIBRARY_NAME} PRIVATE "MASTER_SLAVE_CONTROLLER_BUILDING_DLL")
+# prevent pluginlib from using boost
+target_compile_definitions(${LIBRARY_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+pluginlib_export_plugin_description_file(controller_interface plugin.xml)
+
+# INSTALL
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS ${LIBRARY_NAME}
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_dependencies(
+  controller_interface
+  hardware_interface
+  rclcpp
+  rclcpp_lifecycle
+)
+ament_export_include_directories(
+  include
+)
+ament_export_libraries(
+  ${LIBRARY_NAME}
+)
+
+ament_package()

--- a/master_slave_controller/include/master_slave_controller/master_slave_controller.hpp
+++ b/master_slave_controller/include/master_slave_controller/master_slave_controller.hpp
@@ -68,6 +68,8 @@ protected:
   master_joint_position_command_interface_;
   std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
   slave_joint_position_command_interface_;
+  std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
+  master_joint_torque_limit_command_interface_;
   std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
   master_joint_position_state_interface_;
   std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>>

--- a/master_slave_controller/include/master_slave_controller/master_slave_controller.hpp
+++ b/master_slave_controller/include/master_slave_controller/master_slave_controller.hpp
@@ -1,0 +1,79 @@
+// Copyright 2021 ShotaAk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef MASTER_SLAVE_CONTROLLER__MASTER_SLAVE_CONTROLLER_HPP_
+#define MASTER_SLAVE_CONTROLLER__MASTER_SLAVE_CONTROLLER_HPP_
+
+#include <string>
+#include <vector>
+
+#include "controller_interface/controller_interface.hpp"
+#include "hardware_interface/loaned_command_interface.hpp"
+#include "hardware_interface/loaned_state_interface.hpp"
+#include "master_slave_controller/visibility_control.h"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+
+namespace master_slave_controller
+{
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+
+class MasterSlaveController : public controller_interface::ControllerInterface
+{
+public:
+  MASTER_SLAVE_CONTROLLER_PUBLIC
+  MasterSlaveController();
+
+  MASTER_SLAVE_CONTROLLER_PUBLIC
+  controller_interface::return_type init(const std::string & controller_name) override;
+
+  MASTER_SLAVE_CONTROLLER_PUBLIC
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  MASTER_SLAVE_CONTROLLER_PUBLIC
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  MASTER_SLAVE_CONTROLLER_PUBLIC
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
+
+  MASTER_SLAVE_CONTROLLER_PUBLIC
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  MASTER_SLAVE_CONTROLLER_PUBLIC
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+  MASTER_SLAVE_CONTROLLER_PUBLIC
+  controller_interface::return_type update() override;
+
+protected:
+  std::vector<std::string> master_joint_names_;
+  std::vector<std::string> slave_joint_names_;
+
+  // For convenience, we have ordered the interfaces so i-th position matches i-th index
+  // in joint_names_
+  std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
+  master_joint_position_command_interface_;
+  std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
+  slave_joint_position_command_interface_;
+  std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
+  master_joint_position_state_interface_;
+  std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
+  slave_joint_position_state_interface_;
+};
+
+}  // namespace master_slave_controller
+
+#endif  // MASTER_SLAVE_CONTROLLER__MASTER_SLAVE_CONTROLLER_HPP_

--- a/master_slave_controller/include/master_slave_controller/master_slave_controller.hpp
+++ b/master_slave_controller/include/master_slave_controller/master_slave_controller.hpp
@@ -61,6 +61,7 @@ public:
 protected:
   std::vector<std::string> master_joint_names_;
   std::vector<std::string> slave_joint_names_;
+  std::vector<bool> invert_inputs_;
 
   // For convenience, we have ordered the interfaces so i-th position matches i-th index
   // in joint_names_

--- a/master_slave_controller/include/master_slave_controller/visibility_control.h
+++ b/master_slave_controller/include/master_slave_controller/visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all rclcpp headers which declare symbols
+ * which are defined in the rclcpp library. When not building the rclcpp
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the rclcpp
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef MASTER_SLAVE_CONTROLLER__VISIBILITY_CONTROL_H_
+#define MASTER_SLAVE_CONTROLLER__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define MASTER_SLAVE_CONTROLLER_EXPORT __attribute__((dllexport))
+#define MASTER_SLAVE_CONTROLLER_IMPORT __attribute__((dllimport))
+#else
+#define MASTER_SLAVE_CONTROLLER_EXPORT __declspec(dllexport)
+#define MASTER_SLAVE_CONTROLLER_IMPORT __declspec(dllimport)
+#endif
+#ifdef MASTER_SLAVE_CONTROLLER_BUILDING_DLL
+#define MASTER_SLAVE_CONTROLLER_PUBLIC MASTER_SLAVE_CONTROLLER_EXPORT
+#else
+#define MASTER_SLAVE_CONTROLLER_PUBLIC MASTER_SLAVE_CONTROLLER_IMPORT
+#endif
+#define MASTER_SLAVE_CONTROLLER_PUBLIC_TYPE MASTER_SLAVE_CONTROLLER_PUBLIC
+#define MASTER_SLAVE_CONTROLLER_LOCAL
+#else
+#define MASTER_SLAVE_CONTROLLER_EXPORT __attribute__((visibility("default")))
+#define MASTER_SLAVE_CONTROLLER_IMPORT
+#if __GNUC__ >= 4
+#define MASTER_SLAVE_CONTROLLER_PUBLIC __attribute__((visibility("default")))
+#define MASTER_SLAVE_CONTROLLER_LOCAL __attribute__((visibility("hidden")))
+#else
+#define MASTER_SLAVE_CONTROLLER_PUBLIC
+#define MASTER_SLAVE_CONTROLLER_LOCAL
+#endif
+#define MASTER_SLAVE_CONTROLLER_PUBLIC_TYPE
+#endif
+
+#endif  // MASTER_SLAVE_CONTROLLER__VISIBILITY_CONTROL_H_

--- a/master_slave_controller/package.xml
+++ b/master_slave_controller/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>master_slave_controller</name>
+  <version>0.1.0</version>
+  <description>Master slave controller</description>
+  <maintainer email="macakasit@gmail.com">shotaak</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>controller_interface</depend>
+  <depend>hardware_interface</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <build_depend>pluginlib</build_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/master_slave_controller/plugin.xml
+++ b/master_slave_controller/plugin.xml
@@ -1,0 +1,9 @@
+<library path="master_slave_controller">
+  <class name="master_slave_controller/MasterSlaveController"
+    type="master_slave_controller::MasterSlaveController"
+    base_class_type="controller_interface::ControllerInterface">
+  <description>
+    Master slave controller for CRANE+V2 and CRANE-X7.
+  </description>
+  </class>
+</library>

--- a/master_slave_controller/src/master_slave_controller.cpp
+++ b/master_slave_controller/src/master_slave_controller.cpp
@@ -1,0 +1,207 @@
+// Copyright 2021 ShotaAk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "master_slave_controller/master_slave_controller.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+
+namespace master_slave_controller
+{
+using hardware_interface::LoanedCommandInterface;
+
+MasterSlaveController::MasterSlaveController()
+: controller_interface::ControllerInterface(),
+  master_joint_names_({}),
+  slave_joint_names_({})
+{}
+
+controller_interface::return_type
+MasterSlaveController::init(const std::string & controller_name)
+{
+  // initialize lifecycle node
+  auto ret = ControllerInterface::init(controller_name);
+  if (ret != controller_interface::return_type::SUCCESS) {
+    return ret;
+  }
+
+  // with the lifecycle node being initialized, we can declare parameters
+  node_->declare_parameter<std::vector<std::string>>("master_joints", master_joint_names_);
+  node_->declare_parameter<std::vector<std::string>>("slave_joints", slave_joint_names_);
+
+  return controller_interface::return_type::SUCCESS;
+}
+
+CallbackReturn MasterSlaveController::on_configure(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  master_joint_names_ = node_->get_parameter("master_joints").as_string_array();
+  if (master_joint_names_.empty()) {
+    RCLCPP_ERROR(get_node()->get_logger(), "'master_joints' parameter was empty");
+    return CallbackReturn::ERROR;
+  }
+
+  slave_joint_names_ = node_->get_parameter("slave_joints").as_string_array();
+  if (slave_joint_names_.empty()) {
+    RCLCPP_ERROR(get_node()->get_logger(), "'slave_joints' parameter was empty");
+    return CallbackReturn::ERROR;
+  }
+
+  RCLCPP_INFO_STREAM(get_node()->get_logger(), "configure successful");
+  return CallbackReturn::SUCCESS;
+}
+
+controller_interface::InterfaceConfiguration
+MasterSlaveController::command_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration conf;
+  conf.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  conf.names.reserve(master_joint_names_.size() + slave_joint_names_.size());
+  for (const auto & joint_name  : master_joint_names_) {
+    conf.names.push_back(joint_name + "/" + hardware_interface::HW_IF_POSITION);
+  }
+  for (const auto & joint_name  : slave_joint_names_) {
+    conf.names.push_back(joint_name + "/" + hardware_interface::HW_IF_POSITION);
+  }
+  return conf;
+}
+
+controller_interface::InterfaceConfiguration
+MasterSlaveController::state_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration conf;
+  conf.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  conf.names.reserve(master_joint_names_.size() + slave_joint_names_.size());
+  for (const auto & joint_name  : master_joint_names_) {
+    conf.names.push_back(joint_name + "/" + hardware_interface::HW_IF_POSITION);
+  }
+  for (const auto & joint_name  : slave_joint_names_) {
+    conf.names.push_back(joint_name + "/" + hardware_interface::HW_IF_POSITION);
+  }
+  return conf;
+}
+
+// Fill ordered_interfaces with references to the matching interfaces
+// in the same order as in joint_names
+template<typename T>
+bool get_ordered_interfaces(
+  std::vector<T> & unordered_interfaces, const std::vector<std::string> & joint_names,
+  const std::string & interface_type, std::vector<std::reference_wrapper<T>> & ordered_interfaces)
+{
+  // command_interfaces or state_interfacesから特定のinterfaceを抽出する
+  // interfaces_[joint1(pos), joint1(vel), joint2(pos), joint2(vel), ...]
+  // -> position_interfaces[joint1(pos), joint2(pos), ...]
+  for (const auto & joint_name : joint_names) {
+    for (auto & command_interface : unordered_interfaces) {
+      if ((command_interface.get_name() == joint_name) &&
+        (command_interface.get_interface_name() == interface_type))
+      {
+        ordered_interfaces.push_back(std::ref(command_interface));
+      }
+    }
+  }
+
+  return joint_names.size() == ordered_interfaces.size();
+}
+
+CallbackReturn MasterSlaveController::on_activate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  if (!get_ordered_interfaces(
+      command_interfaces_, master_joint_names_, hardware_interface::HW_IF_POSITION,
+      master_joint_position_command_interface_))
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Expected %u position command interfaces of master joints, got %u",
+      master_joint_names_.size(), master_joint_position_command_interface_.size());
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+  if (!get_ordered_interfaces(
+      state_interfaces_, master_joint_names_, hardware_interface::HW_IF_POSITION,
+      master_joint_position_state_interface_))
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Expected %u position state interfaces of master joints, got %u",
+      master_joint_names_.size(), master_joint_position_state_interface_.size());
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+
+  if (!get_ordered_interfaces(
+      command_interfaces_, slave_joint_names_, hardware_interface::HW_IF_POSITION,
+      slave_joint_position_command_interface_))
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Expected %u position command interfaces of slave joints, got %u",
+      slave_joint_names_.size(), slave_joint_position_command_interface_.size());
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+  if (!get_ordered_interfaces(
+      state_interfaces_, slave_joint_names_, hardware_interface::HW_IF_POSITION,
+      slave_joint_position_state_interface_))
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Expected %u position state interfaces of slave joints, got %u",
+      slave_joint_names_.size(), slave_joint_position_state_interface_.size());
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn MasterSlaveController::on_deactivate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  master_joint_position_command_interface_.clear();
+  master_joint_position_state_interface_.clear();
+  slave_joint_position_command_interface_.clear();
+  slave_joint_position_state_interface_.clear();
+  release_interfaces();
+  return CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type MasterSlaveController::update()
+{
+  // current state update
+  const auto master_joint_num = master_joint_names_.size();
+  const auto slave_joint_num = slave_joint_names_.size();
+
+  if(master_joint_num != slave_joint_num){
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Master joints [%d] and slave joints [%d] are not same size",
+      master_joint_num, slave_joint_num);
+    return controller_interface::return_type::ERROR;
+  }
+
+  for (auto index = 0ul; index < master_joint_num; ++index) {
+    auto master_pos = master_joint_position_state_interface_[index].get().get_value();
+    slave_joint_position_command_interface_[index].get().set_value(master_pos);
+  }
+  return controller_interface::return_type::SUCCESS;
+}
+
+}  // namespace master_slave_controller
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(
+  master_slave_controller::MasterSlaveController, controller_interface::ControllerInterface)


### PR DESCRIPTION
CRANE+V2のジョイント角度に合わせてCRANE-X7を動かす、
`master_slave_controller`を追加します。

また、CRANE-X7を動かすために`crane_x7_hardware`パッケージを追加します。

CRANE+V2とCRANE-X7をPCに接続した後、
`$ ros2 launch crane_plus_control crane_master_slave_control.launch.py`
を実行することで動作します。



https://user-images.githubusercontent.com/18494952/108342147-cfbfbe80-721d-11eb-814e-30ac09eeb5fb.mov

※このPRは[ROS勉強会](https://rosjp.connpass.com/event/200588/)で参照されるので、できればずっと残しておきたい。